### PR TITLE
edk2-TemplateSpecification: Use publish-gitbook-docs action

### DIFF
--- a/.github/workflows/gitbook-action.yml
+++ b/.github/workflows/gitbook-action.yml
@@ -1,38 +1,24 @@
 name: 'Gitbook Action Build'
 on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
   push:
     branches:
       - master
+      - main
       - release/*
   workflow_dispatch:
 
 jobs:
-  build:
+  publish-gitbook-docs:
+    name: Publish GitBook Docs
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout action
-      uses: actions/checkout@v2
-    - name: Get Branch
-      run: |
-        branch=${{ github.ref_name }}
-        pubdir=${branch/master/draft}
-        pubdir=${pubdir////-}
-        echo "ON_PUSH_BRANCH_NAME=$branch" >> $GITHUB_ENV
-        echo "ON_PUSH_PUBDIR=$pubdir" >> $GITHUB_ENV
-    - name: Gitbook Action
-      uses: zanderzhao/gitbook-action@v1.2.4
-      with:
-        token: ${{secrets.GITBOOK_ACTION_PERSONAL_TOKEN}}
-        source_branch: ${{env.ON_PUSH_BRANCH_NAME}}
-        publish_branch: gh-pages
-        publish_dir: ${{env.ON_PUSH_PUBDIR}}
-        publish_remove_last_build: true
-        gitbook_pdf: true
-        gitbook_pdf_dir: /
-        gitbook_pdf_name: ${{ github.event.repository.name }}-${{env.ON_PUSH_PUBDIR}}
-        gitbook_epub: true
-        gitbook_epub_dir: /
-        gitbook_epub_name: ${{ github.event.repository.name }}-${{env.ON_PUSH_PUBDIR}}
-        gitbook_mobi: true
-        gitbook_mobi_dir: /
-        gitbook_mobi_name: ${{ github.event.repository.name }}-${{env.ON_PUSH_PUBDIR}}
+      - name: Publish GitBook Docs
+        uses: tianocore-docs/publish-gitbook-docs@main
+        with:
+          token: ${{secrets.GITBOOK_ACTION_PERSONAL_TOKEN}}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# tianocore-docs CODEOWNERS
+
+* @leiflindholm @mdkinney @ajfish @ardbiesheuvel @makubacki


### PR DESCRIPTION
Update edk2-TemplateSpecification to use the publish-gitbook-docs action that verifies the Signed-off-by and Contributed-under tags in the commit message and if that passes, also generates the HTML, PDF, and ePub versions of the documents in either the pr-pages branch when processing a pull request or the gh-pages branch when processing a push.

Also a CODEOWNERS files with the current TianoCore stewards as the default CODEOWNERS. Document specific CODEOWNERS can be added later as required.

Contributed-under: TianoCore Contribution Agreement 1.1